### PR TITLE
add checks to BayesFIT

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,7 +12,8 @@ Authors@R: c(person(given = "Edgar", family = "Merkle",
                     role = "ctb",
                     email = "maugavilla@gmail.com"),
              person(given = c("Terrence", "D."), family = "Jorgensen",
-                    role = "ctb") 
+                    role = "ctb",
+                    email = "T.D.Jorgensen@uva.nl")
             )
 Description: Fit a variety of Bayesian latent variable models, including confirmatory
    factor analysis, structural equation models, and latent growth curve models.

--- a/R/ctr_bayes_fit.R
+++ b/R/ctr_bayes_fit.R
@@ -1,81 +1,118 @@
-## functions applying traditional SEM fit criteria to Bayesian models,
-## from Mauricio Garnier-Villareal with code contributions from
-## Terrence Jorgensen and Rens van de Schoot.
+### Mauricio Garnier-Villareal and Terrence D. Jorgensen
+### Last updated: 19 March 2018
+### functions applying traditional SEM fit criteria to Bayesian models.
+### Inspired by, and adpated from, Rens van de Schoot's idea for BRMSEA, as
+### published in http://dx.doi.org/10.1177/0013164417709314
 
-BayesFIT <- function(fit, fit_null=NULL){
+
+## Public function (eventually, after documenting and peer review)
+BayesFIT <- function(fit, rescale = c("devM","ppmc"), fit_null = NULL) {
+  rescale <- as.character(rescale[1])
+  if (rescale != "devM") stop('Only rescale="devM" is currently available')
+  if (rescale == "ppmc" && blavInspect(fit, 'ntotal') < 1000)
+    warning("Hoofs et al.'s proposed BRMSEA (and derivative indices based on",
+            " the posterior predictive distribution) was only proposed for",
+            " evaluating models fit to very large samples (N > 1000).")
+  
   chisqs <- as.numeric(apply(fit@external$samplls, 2,
                              function(x) 2*(x[,2] - x[,1])))
   fit_pd <- fitMeasures(fit, 'p_loo')
-
-  if( is.null(fit_null) ){
+  # if (rescale = "ppmc") {
+  #   reps <- as.numeric(apply(fit@external$replls, 2,
+  #                            function(x) 2*(x[,2] - x[,1])))
+  # } else reps <- NULL
+  
+  if (is.null(fit_null)) {
     null_model <- FALSE
     chisq_null <- NULL
+    # reps_null <- NULL
     pD_null <- NULL
   } else {
     null_model <- TRUE
     chisq_null <- as.numeric(apply(fit_null@external$samplls, 2,
                                    function(x) 2*(x[,2] - x[,1])))
-    pD_null <- fitMeasures(fit_null, 'p_loo')
+    if (length(chisqs) != length(chisq_null)) {
+      null_model <- FALSE
+      chisq_null <- NULL
+      # reps_null <- NULL
+      pD_null <- NULL
+      warning("Incremental fit indices were not calculated.",
+              " Save equal number of draws from the posterior of both",
+              " the hypothesized and null models.")
+    } else {
+      # if (rescale = "ppmc") {
+      #   reps_null <- as.numeric(apply(fit_null@external$replls, 2,
+      #                                 function(x) 2*(x[,2] - x[,1])))
+      # }
+      pD_null <- fitMeasures(fit_null, 'p_loo')
+    }
   }
 
-  ff <- BayesRelFit(obs=chisqs,
-                    nvar=fit@Model@nvar,
-                    pD=fit_pd, N=blavInspect(fit, 'ntotal'),
-                    ms=blavInspect(fit, 'meanstructure'),
-                    Min1=TRUE, Ngr=blavInspect(fit, 'ngroups'),
-                    null_model=null_model, obs_null=chisq_null,
-                    pD_null=pD_null)
-  
+  ff <- BayesRelFit(obs = chisqs, # reps = reps,
+                    nvar = fit@Model@nvar, pD = fit_pd,
+                    N = blavInspect(fit, 'ntotal'), Min1 = FALSE,
+                    ms = blavInspect(fit, 'meanstructure'),
+                    Ngr = blavInspect(fit, 'ngroups'), null_model = null_model,
+                    obs_null = chisq_null, # reps_null = reps_null,
+                    pD_null = pD_null)
   return(ff)
 }
 
 
-### Bayesian RMSEA from Rens
-### MGV: change the correction method, not longer like Rens
-### MGV: modified to also calculate gammahat, adjusted gammahat
-### TDJ: added McDonald's centrality index
-### if a null model information provided, it calculates CFI, TLI, NFI
-BayesRelFit <-function(obs, nvar, pD, N, ms = TRUE, Min1 = TRUE,
-                       Ngr = 1, null_model=TRUE, obs_null=NULL,
-                       pD_null=NULL){
-
+### Hidden function to calculate Bayesian fit indices
+### Rens: Bayesian RMSEA adapted from http://dx.doi.org/10.1177/0013164417709314
+### MGV:  change the correction method, not longer like Rens
+### TDJ:  added argument to select Rens' method ("ppmc") vs. ours ("devM")
+### MGV:  modified to also calculate gammahat, adjusted gammahat
+### TDJ:  added McDonald's centrality index
+### MGV:  If a null model information provided, it calculates CFI, TLI, NFI
+BayesRelFit <- function(obs, reps = NULL, nvar, pD, N, ms = TRUE, Min1 = FALSE,
+                        Ngr = 1, rescale = c("devM","ppmc"), null_model = TRUE,
+                        obs_null = NULL, reps_null = NULL, pD_null = NULL) {
+  if (Min1) N <- N - 1
+  rescale <- as.character(rescale[1])
+  if (rescale == "devM") {
+    reps <- pD
+    if (!is.null(null_model)) reps_null <- pD_null
+  } else stop('Only rescale="devM" is currently available')
+  if (rescale == "ppmc" && (is.null(reps) || (null_model && is.null(reps_null))))
+    stop('rescale="ppmc" requires non-NULL reps argument (and reps_null, if applicable).')
+  
   ## Compute number of modeled moments
-  if(ms) p <- (((nvar * (nvar + 1)) / 2) + nvar)
-  if(!ms) p <- (((nvar * (nvar + 1))/ 2) + 0)
+  p <- ((nvar * (nvar + 1)) / 2)
+  if (ms) p <- p + nvar
   p <- p * Ngr
-  # # Substract parameters and estimated parameters
+  ## Substract parameters and estimated parameters
   dif.ppD <- p - pD
-  nonc <- obs - pD - dif.ppD # == obs - p
-  # # Correct if numerator is smaller than zero
+  nonc <- obs - reps - dif.ppD # == obs - p when rescale == "devM" because reps = pD
+  ## Correct if numerator is smaller than zero
   nonc[nonc < 0] <- 0
-  # # Compute BRMSEA (with or without the -1 correction)
-  if(Min1)
-    BRMSEA <- sqrt(nonc / (dif.ppD * (N - 1)))*sqrt(Ngr)
-  if(!Min1) BRMSEA <- sqrt(nonc / (dif.ppD * N))*sqrt(Ngr)
-
+  ## Compute BRMSEA
+  BRMSEA <- sqrt(nonc / (dif.ppD * N)) * sqrt(Ngr)
+  
   ## compute GammaHat and adjusted GammaHat
-  gammahat <- nvar / ( nvar+2* ((nonc)/(N-1))  )
-  adjgammahat <- 1 - (((Ngr * nvar * (nvar + 1))/2)/dif.ppD) * (1 - gammahat)
+  gammahat <- nvar / (nvar + 2*nonc/N)
+  adjgammahat <- 1 - (p / dif.ppD) * (1 - gammahat)
   
   ## compute McDonald's centrality index
-  Mc <- exp(-.5 * nonc/(N-1) )
+  Mc <- exp(-.5 * nonc/N)
+  
+  out <- cbind(chi_adj = obs - reps, df_adj = dif.ppD, BRMSEA = BRMSEA,
+               BGammaHat = gammahat, adjBGammaHat = adjgammahat, BMc = Mc)
   
   ## calculate fit when null model is provided
   if (null_model) {
     dif.ppD_null <- p - pD_null
-    nonc_null <- ( ( obs_null-pD_null ) - dif.ppD_null )
+    nonc_null <- (obs_null - reps_null) - dif.ppD_null
     
-    cfi <- (nonc_null - nonc)/nonc_null 
-    tli <- ((( obs_null-pD_null )/dif.ppD_null) - (( obs-pD )/dif.ppD)) / (((( obs_null-pD_null )/dif.ppD_null))-1) 
-    nfi <- (( obs_null-pD_null ) - ( obs-pD )) / ( obs_null-pD_null )
+    cfi <- 1 - (nonc / nonc_null)
+    tli_null_part <- (obs_null - reps_null) / dif.ppD_null
+    tli <- (tli_null_part - (obs - reps) / dif.ppD) / (tli_null_part - 1)
+    nfi <- ((obs_null - reps_null) - (obs - reps)) / (obs_null - reps_null)
     
-    out <- cbind(chi_adj=obs-pD, df_adj=dif.ppD, 
-                 BRMSEA=BRMSEA, BGammaHat=gammahat, adjBGammaHat=adjgammahat, 
-                 BMc = Mc, BCFI=cfi, BTLI=tli, BNFI=nfi)
-  } else {
-    out <- cbind(chi_adj=obs-pD, df_adj=dif.ppD,
-                 BRMSEA=BRMSEA, BGammaHat=gammahat, adjBGammaHat=adjgammahat, BMc = Mc)
+    out <- cbind(out, BCFI = cfi, BTLI = tli, BNFI = nfi)
   }
   
+  class(out) <- c("lavaan.matrix","matrix")
   return(out)
 }

--- a/R/postpred.R
+++ b/R/postpred.R
@@ -1,14 +1,35 @@
+### Ed Merkle
+### posterior predictive model checking
+###   - returns PPP value to store in @test slot
+###   - returns posterior predictive distribution (PP-Dist) for additional
+###     discrepancy functions evaluated on observed and replicated data
+### Last updated: 20 March 2018
+### Mauricio Garnier-Villarreal:
+###   - update to return "chisq" PP-Dist from observed and replicated data
+### Terrence D. Jorgensen:
+###   - added "discFUN" argument to evaluate custom discrepancy function(s)
+###     on observed and replicated data.  This is distinct from the "measure"
+###     argument, which only returns values from fitMeasures().
+###   - made notes with "FIXME TDJ" in places where postpred() could be updated
+
 postpred <- function(lavpartable, lavmodel, lavoptions, 
                      lavsamplestats, lavdata, lavcache, lavjags,
-                     samplls, measure = "logl", thin = 1) {
-
+                     samplls, measure = "logl", thin = 1, discFUN = NULL) {
+    ## check custom discrepancy function(s)
+    if (!is.null(discFUN)) {
+      allFuncs <- if (is.list(discFUN)) all(sapply(discFUN, is.function)) else FALSE
+      if (!(is.function(discFUN) || allFuncs)) stop('The "discFUN" argument must',
+                                                    ' be a (list of) function(s).')
+    }
+    discFUN <- NULL # Not implemented yet
+  
     ## run through lavjags$mcmc, generate data from various posterior
     ## samples. thin like we do in samp_lls
     lavmcmc <- make_mcmc(lavjags)
     samp.indices <- sampnums(lavjags, thin=thin)
     n.chains <- length(lavmcmc)
     psamp <- length(samp.indices)
-  
+    
     ## parallel across chains if we can
     ncores <- NA
     loop.comm <- "lapply"
@@ -16,24 +37,24 @@ postpred <- function(lavpartable, lavmodel, lavoptions,
       ncores <- min(n.chains, parallel::detectCores())
       loop.comm <- "mclapply"
     }
-  
+    
     origlavmodel <- lavmodel
     origlavdata <- lavdata
-
+  
     loop.args <- list(X = 1:n.chains, FUN = function(j){
-      ind <- csdist <- rep(NA, psamp)
+      ind <- csdist <- csboots <- rep(NA, psamp)
       for(i in 1:psamp){
         ## translate each posterior sample to a model-implied mean vector +
         ## cov matrix.
         lavmodel <- fill_params(lavmcmc[[j]][samp.indices[i],],
                                 origlavmodel, lavpartable)
-
+  
         ## generate data (some code from lav_bootstrap.R)
         implied <- lav_model_implied(lavmodel)
         Sigma.hat <- implied$cov
         Mu.hat <- implied$mean
         dataeXo <- lavdata@eXo
-
+  
         dataX <- vector("list", length=lavdata@ngroups)
         for(g in 1:lavsamplestats@ngroups) {
           dataX[[g]] <- MASS::mvrnorm(n     = lavsamplestats@nobs[[g]],
@@ -46,7 +67,7 @@ postpred <- function(lavpartable, lavmodel, lavoptions,
           if(sum(allmis) > 0){
             origlavdata@X[[g]] <- origlavdata@X[[g]][-which(allmis),]
           }
-
+  
           ## fixed x should also be generated, so don't need this:
           ##x.idx <- lavsamplestats@x.idx[[g]]
           ##if(!is.null(x.idx) && length(x.idx) > 0L){
@@ -55,7 +76,7 @@ postpred <- function(lavpartable, lavmodel, lavoptions,
           
           dataX[[g]][is.na(origlavdata@X[[g]])] <- NA
         }
-
+  
         ## compute (i) X2 of generated data and model-implied
         ## moments, along with (ii) X2 of real data and model-implied
         ## moments.
@@ -68,11 +89,13 @@ postpred <- function(lavpartable, lavmodel, lavoptions,
                              #    lavcache = lavcache,
                              #    lavdata = origlavdata,
                              #    measure = measure)
-
+        
+        #FIXME TDJ: apply custom "discFUN" here
+  
         ## check for missing, to see if we can easily get baseline ll for chisq
         mis <- FALSE
         if(any(is.na(unlist(lavdata@X)))) mis <- TRUE
-
+  
         if(!mis){
           lavdata@X <- dataX
           x.idx <- lavsamplestats@x.idx[[g]]
@@ -82,18 +105,21 @@ postpred <- function(lavpartable, lavmodel, lavoptions,
               lavsamplestats@cov.x[[g]] <- cov(lavdata@X[[g]][,x.idx,drop=FALSE])
             }
           }
-
+  
           chisq.boot <- 2*diff(get_ll(lavmodel = lavmodel,
                                       lavsamplestats = lavsamplestats,
                                       lavdata = lavdata,
                                       measure = measure))
+          #FIXME TDJ: no way to apply custom "discFUN" here. Use hack below?
         } else {
           ## we need lavaan to get the saturated log-l for missing data (EM)
                                          
           # YR: ugly hack to avoid lav_samplestats_from_data:
           # reconstruct data + call lavaan()
           # ed: if we need lavaan() anyway, might as well
-          # get the chisq while we're here:
+          #     get the chisq while we're here:
+          # TDJ: this also enables us to apply custom "discFUN" argument to
+          #     fitted lavaan object -- also use this hack when !is.null(discFUN)?
           DATA.X <- do.call("rbind", dataX)
           colnames(DATA.X) <- lavdata@ov.names[[1L]]
           DATA.eXo <- do.call("rbind", dataeXo)
@@ -111,7 +137,7 @@ postpred <- function(lavpartable, lavmodel, lavoptions,
             DATA <- DATA.X
           }
           DATA <- as.data.frame(DATA)
-
+  
           lavoptions2 <- lavoptions
           lavoptions2$verbose <- FALSE
           lavoptions2$estimator <- "ML"
@@ -139,13 +165,13 @@ postpred <- function(lavpartable, lavmodel, lavoptions,
           }
           # bootSampleStats <- out@SampleStats
           # end of ugly hack
-
+  
           if(measure %in% c("logl", "chisq")){
             chisq.boot <- fitMeasures(out, "chisq")
           } else {
             chisq.boot <- fitMeasures(out, measure)
           }
-
+  
           ## see lines 286-298 of lav_bootstrap to avoid fixed.x errors?
           ## chisq.boot <- 2*diff(get_ll(lavmodel = lavmodel,
           ##                             lavpartable = lavpartable,
@@ -158,22 +184,33 @@ postpred <- function(lavpartable, lavmodel, lavoptions,
         ## record whether observed value is larger
         ind[i] <- chisq.obs < chisq.boot
         csdist[i] <- chisq.obs
+        csboots[i] <- chisq.boot
+        #FIXME TDJ: extract and organize custom "discFUN" output here
+        
       } # i
-      list(ind = ind, csdist = csdist)
+      
+      result <- list(ind = ind, csdist = csdist, csboots = csboots)
+      # if (!is.null(discFUN)) result <- c(result, discFUN_results)
+      result
     })
-
+  
     if(loop.comm == "mclapply"){
         loop.args <- c(loop.args, list(mc.cores = ncores))
         res <- do.call(parallel::mclapply, loop.args)
     } else {
         res <- do.call(lapply, loop.args)
     }
-
+  
     ind <- unlist(lapply(res, function(x) x$ind))
     csdist <- unlist(lapply(res, function(x) x$csdist))
-
+    csboots <- unlist(lapply(res, function(x) x$csboots))
+    #FIXME TDJ: extract custom "discFUN" output here
+    
     ppval <- mean(as.numeric(ind))
     cspi <- quantile(as.numeric(csdist), c(.025,.975))
     
-    list(ppval=ppval, cspi=cspi)
+    #FIXME TDJ: check whether to add custom "discFUN" output to returned list
+    list(ppval = ppval, cspi = cspi, chisqs = cbind(obs = csdist, reps = csboots))
 }
+
+


### PR DESCRIPTION
Hi Ed,

I mostly just cleaned up our code and added logical checks/warnings like I discussed with you last week.  But I also added a `rescale=` argument to request how they are calculated.   `rescale="ppmc"` would rescale the observed-data discrepancies by replicated-data discrepancies (as in Rens' paper), whereas `rescale="devM"` would rescale the observed-data discrepancies by _pD_ to mimic the deviance evaluated at the posterior mean (as in our paper).  Currently, `rescale="ppmc"` returns an error message that it is not yet available.  We will make sure to provide documentation before we request that this function becomes public.

To make them available, I wondered how easy it would be to add `@external$replls` to the fitted blavaan object.  Judging from the source code, probably never going to happen.  

Since the `postpred()` function is only ever called once (only to save PPP, nothing about deviances/`"chisq"` across the posterior), would you be open to me separating that function into smaller components?  I envision the components working together to return the same result, but allowing for more flexibility (some accessible by the user).  So if there is a separate function for generating replicated data from each posterior draw, those could be fed to a separate function to calculate discrepancies (therefore accessible for calculating Rens' BRMSEA).  But it would also allow other user-specified discrepancy functions to be calculated for each posterior draw (e.g., SRMR or model-implied factor correlations, as seen in Levy's 2011 paper). 

I don't plan to have time to start that anytime soon, but please let me know what you think, so I can brainstorm about it.

Thanks,
Terry