### PR TITLE
make blavFitIndices public

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -6,7 +6,7 @@ importFrom("utils",
            "packageDescription", "str", "write.table", "packageVersion")
 
 importFrom("stats", 
-           "approx", "density", "dnorm", "pnorm", "rgamma", "rnorm",
+           "approx", "density", "median", "dnorm", "pnorm", "rgamma", "rnorm",
            "runif", "quantile", "rWishart", "cov", "cor",
            "coef", "logLik",
            "residuals", "resid",
@@ -40,7 +40,7 @@ importFrom("MCMCpack",
 
 importFrom("coda",
            "mcmc.list",
-           "mcmc",
+           "mcmc", "as.mcmc",
            "HPDinterval")
 
 importFrom("mnormt",
@@ -54,6 +54,6 @@ importFrom("loo",
            "loo", "waic", "compare")
 
 export("blavaan", "bcfa", "bsem", "bgrowth", "dpriors", "BF", "blavCompare",
-       "blavTech", "blavInspect")
+       "blavTech", "blavInspect", "blavFitIndices")
 
 S3method(plot, blavaan)

--- a/R/ctr_bayes_fit.R
+++ b/R/ctr_bayes_fit.R
@@ -1,5 +1,5 @@
 ### Mauricio Garnier-Villareal and Terrence D. Jorgensen
-### Last updated: 11 April 2018
+### Last updated: 12 April 2018
 ### functions applying traditional SEM fit criteria to Bayesian models.
 ### Inspired by, and adpated from, Rens van de Schoot's idea for BRMSEA, as
 ### published in http://dx.doi.org/10.1177/0013164417709314
@@ -174,6 +174,8 @@ blavFitIndices <- function(object, pD = c("loo","waic","dic"),
                        reps_null = reps_null, pD_null = pD_null)
   }
   
+  nChains <- blavInspect(object, 'n.chains')
+  out@details <- c(out@details, list(n.chains = nChains))
   out
 }
 

--- a/R/ctr_bayes_fit.R
+++ b/R/ctr_bayes_fit.R
@@ -1,45 +1,143 @@
 ### Mauricio Garnier-Villareal and Terrence D. Jorgensen
-### Last updated: 20 March 2018
+### Last updated: 11 April 2018
 ### functions applying traditional SEM fit criteria to Bayesian models.
 ### Inspired by, and adpated from, Rens van de Schoot's idea for BRMSEA, as
 ### published in http://dx.doi.org/10.1177/0013164417709314
 
 
+## -----------------
+## Class and Methods
+## -----------------
+
+setClass("blavFitIndices",
+         representation(details = "list",
+                        # chisq = "numeric", df = "numeric", # Bayesian analogs
+                        # pD = "character", rescale = "character", # store choices
+                        # list of vectors, each storing the posterior of 1 index
+                        indices = "list"))
+
+summary.blavFitIndices <- function(object,
+                                   central.tendency = c("mean","median","mode"),
+                                   hpd = TRUE, prob = .90) {
+  if (!is.character(central.tendency)) {
+    stop('blavaan ERROR: central.tendency must be a character vector')
+  }
+  central.tendency <- tolower(central.tendency)
+  invalid <- setdiff(central.tendency, c("mean","median","mode","eap","map"))
+  if (length(invalid)) {
+    stop('blavaan ERROR: Invalid choice(s) of central.tendency:\n"',
+         paste(invalid, collapse = '", "'), '"')
+  }
+  ## collect list of functions to apply to each index
+  FUN <- function(x) {
+    out <- numeric(0)
+    
+    if ("mean" %in% central.tendency || "eap" %in% central.tendency) {
+      out <- c(out, EAP = mean(x, na.rm = TRUE))
+    }
+    
+    if ("median" %in% central.tendency) {
+      out <- c(out, Median = median(x, na.rm = TRUE))
+    }
+    
+    if ("mode" %in% central.tendency || "map" %in% central.tendency) {
+      ## can the modeest package be used?
+      if (suppressMessages(requireNamespace("modeest", quietly = TRUE))) {
+        out <- c(out, MAP =  modeest::mlv(x, method = "kernel", na.rm = TRUE)$M)
+      } else {
+        ## if not, use the quick-and-dirty way
+        dd <- density(x, na.rm = TRUE)
+        out <- c(out, MAP = dd$x[which.max(dd$y)])
+      }
+    }
+    
+    out <- c(out, SD = sd(x, na.rm = TRUE))
+    
+    if (hpd) {
+      if (!"package:coda" %in% search()) attachNamespace("coda")
+      out <- c(out, HPDinterval(as.mcmc(x), prob = prob)[1, ] )
+    }
+    
+    out
+  }
+  ## apply function to each fit index
+  indexSummaries <- lapply(object@indices, FUN)
+  out <- as.data.frame(do.call(rbind, indexSummaries))
+  class(out) <- c("lavaan.data.frame","data.frame")
+  attr(out, "header") <- paste0("Posterior summary statistics and highest",
+                                " posterior density (HPD) ", round(prob*100, 2),
+                                "% credible intervals for ",
+                                object@details$rescale,
+                                "-based fit indices:", sep = "")
+  out
+}
+setMethod("summary", "blavFitIndices", summary.blavFitIndices)
+
+setMethod("show", "blavFitIndices", function(object) {
+  cat("Posterior mean (EAP) of ", object@details$rescale,
+      "-based fit indices:\n\n", sep = "")
+  fits <- getMethod("summary","blavFitIndices")(object, "mean", hpd = FALSE)
+  out <- fits$EAP
+  names(out) <- rownames(fits)
+  class(out) <- c("lavaan.vector","numeric")
+  print(out)
+  invisible(object)
+})
+
+
+
+## --------------------
+## Constructor Function
+## --------------------
+
 ## Public function (eventually, after documenting and peer review)
-BayesFIT <- function(fit, pD = c("loo","waic","dic"),
-                     rescale = c("devM","ppmc"), fit_null = NULL) {
+blavFitIndices <- function(object, pD = c("loo","waic","dic"),
+                           rescale = c("devM","ppmc","mcmc"),
+                           fit.measures = "all", baseline.model = NULL) {
   ## check arguments
   pD <- tolower(as.character(pD[1]))
-  if (!pD %in% c("loo","waic","dic")) stop('Invalid choice of "pD" argument')
+  if (!pD %in% c("loo","waic","dic")) {
+    stop('blavaan ERROR: Invalid choice of "pD" argument')
+  }
 
   rescale <- tolower(as.character(rescale[1])) #FIXME: make sure references to "devM" check for "devm"
-  if (rescale == "ppmc" && blavInspect(fit, 'ntotal') < 1000)
-    warning("Hoofs et al.'s proposed BRMSEA (and derivative indices based on",
+  if (rescale == "ppmc" && blavInspect(object, 'ntotal') < 1000)
+    warning("blavaan WARNING: ",
+            "Hoofs et al.'s proposed BRMSEA (and derivative indices based on",
             " the posterior predictive distribution) was only proposed for",
             " evaluating models fit to very large samples (N > 1000).")
   
-  chisqs <- as.numeric(apply(fit@external$samplls, 2,
+  chisqs <- as.numeric(apply(object@external$samplls, 2,
                              function(x) 2*(x[,2] - x[,1])))
-  fit_pd <- fitMeasures(fit, paste0('p_', pD))
-  if (rescale == "ppmc") {
-    reps <- postpred(lavpartable = fit@ParTable,
-                     lavmodel = fit@Model,
-                     lavoptions = fit@Options,
-                     lavsamplestats = fit@SampleStats,
-                     lavdata = fit@Data,
-                     lavcache = fit@Cache,
-                     lavjags = fit@external$mcmcout, #FIXME: Ed, is this correct?
-                     samplls = fit@external$samplls)$chisqs[,"reps"]
+  fit_pd <- fitMeasures(object, paste0('p_', pD))
+  if (rescale == "mcmc") {
+    stop('blavaan ERROR: type = "mcmc" not implemented yet.')
+    ##FIXME TDJ: Call postpred(), just save different information.
+    ## if (!is.null(baseline.model))
+    ##      - Pass baseline model (parTable?) as argument? (priors?!)
+    ##      - Or calculate using baseline posterior chi-squared?
+    ## ff <- postpred(...)$... # extract discFUN() output
+    ## out <- new("blavFitIndices", details = list(rescale = rescale,
+    ##            customized.baseline = !is.null(baseline.model)), indices = ff)
+  } else if (rescale == "ppmc") {
+    reps <- postpred(lavpartable = object@ParTable,
+                     lavmodel = object@Model,
+                     lavoptions = object@Options,
+                     lavsamplestats = object@SampleStats,
+                     lavdata = object@Data,
+                     lavcache = object@Cache,
+                     lavjags = object@external$mcmcout,
+                     samplls = object@external$samplls)$chisqs[,"reps"]
   } else reps <- NULL
   
-  if (is.null(fit_null)) {
+  if (is.null(baseline.model)) {
     null_model <- FALSE
     chisq_null <- NULL
     reps_null <- NULL
     pD_null <- NULL
-  } else {
+  } else if (rescale != "mcmc") {
     null_model <- TRUE
-    chisq_null <- as.numeric(apply(fit_null@external$samplls, 2,
+    chisq_null <- as.numeric(apply(baseline.model@external$samplls, 2,
                                    function(x) 2*(x[,2] - x[,1])))
     if (length(chisqs) != length(chisq_null)) {
       null_model <- FALSE
@@ -51,48 +149,74 @@ BayesFIT <- function(fit, pD = c("loo","waic","dic"),
               " the hypothesized and null models.")
     } else {
       if (rescale == "ppmc") {
-        reps_null <- postpred(lavpartable = fit_null@ParTable,
-                              lavmodel = fit_null@Model,
-                              lavoptions = fit_null@Options,
-                              lavsamplestats = fit_null@SampleStats,
-                              lavdata = fit_null@Data,
-                              lavcache = fit_null@Cache,
-                              lavjags = fit_null@external$mcmcout, #FIXME: Ed, is this correct?
-                              samplls = fit_null@external$samplls)$chisqs[,"reps"]
+        reps_null <- postpred(lavpartable = baseline.model@ParTable,
+                              lavmodel = baseline.model@Model,
+                              lavoptions = baseline.model@Options,
+                              lavsamplestats = baseline.model@SampleStats,
+                              lavdata = baseline.model@Data,
+                              lavcache = baseline.model@Cache,
+                              lavjags = baseline.model@external$mcmcout,
+                              samplls = baseline.model@external$samplls)$chisqs[,"reps"]
       }
-      pD_null <- fitMeasures(fit_null, 'p_loo')
+      pD_null <- fitMeasures(baseline.model, 'p_loo')
     }
   }
-
-  ff <- BayesRelFit(obs = chisqs, reps = reps,
-                    nvar = fit@Model@nvar, pD = fit_pd,
-                    N = blavInspect(fit, 'ntotal'), Min1 = FALSE,
-                    ms = blavInspect(fit, 'meanstructure'),
-                    Ngr = blavInspect(fit, 'ngroups'), rescale = rescale,
-                    null_model = null_model, obs_null = chisq_null,
-                    reps_null = reps_null, pD_null = pD_null)
-  return(ff)
+  
+  if (rescale != "mcmc") {
+    out <- BayesChiFit(obs = chisqs, reps = reps,
+                       nvar = object@Model@nvar, pD = fit_pd,
+                       N = blavInspect(object, 'ntotal'),
+                       Ngr = blavInspect(object, 'ngroups'),
+                       Min1 = blavInspect(object, 'options')$mimic == "EQS",
+                       ms = blavInspect(object, 'meanstructure'),
+                       rescale = rescale, fit.measures = fit.measures,
+                       null_model = null_model, obs_null = chisq_null,
+                       reps_null = reps_null, pD_null = pD_null)
+  }
+  
+  out
 }
 
 
-### Hidden function to calculate Bayesian fit indices
+
+## ----------------
+## Hidden functions
+## ----------------
+
+### function to calculate fit indices from posterior distribution chi-squared
 ### Rens: Bayesian RMSEA adapted from http://dx.doi.org/10.1177/0013164417709314
 ### MGV:  change the correction method, not longer like Rens
 ### TDJ:  added argument to select Rens' method ("ppmc") vs. ours ("devM")
 ### MGV:  modified to also calculate gammahat, adjusted gammahat
 ### TDJ:  added McDonald's centrality index
 ### MGV:  If a null model information provided, it calculates CFI, TLI, NFI
-BayesRelFit <- function(obs, reps = NULL, nvar, pD, N, ms = TRUE, Min1 = FALSE,
-                        Ngr = 1, rescale = c("devM","ppmc"), null_model = TRUE,
-                        obs_null = NULL, reps_null = NULL, pD_null = NULL) {
-  if (Min1) N <- N - 1
+BayesChiFit <- function(obs, reps = NULL, nvar, pD, N, Ngr = 1,
+                        ms = TRUE, Min1 = FALSE,
+                        rescale = c("devM","ppmc"), fit.measures = "all",
+                        null_model = TRUE, obs_null = NULL,
+                        reps_null = NULL, pD_null = NULL) {
+  if (!is.character(fit.measures)) {
+    stop('blavaan ERROR: fit.measures must be a character vector')
+  }
+  fit.measures <- tolower(fit.measures)
+  if (fit.measures == "all") {
+    fit.measures <- c("brmsea","bgammahat","adjbgammahat","bmc")
+    if (null_model) fit.measures <- c(fit.measures, "bcfi","btli","bnfi")
+  }
+  
+  if (Min1) N <- N - Ngr
+  
   rescale <- tolower(as.character(rescale[1]))
   if (rescale == "devm") {
     reps <- pD
     if (!is.null(null_model)) reps_null <- pD_null
   }
-  if (rescale == "ppmc" && (is.null(reps) || (null_model && is.null(reps_null))))
-    stop('rescale="ppmc" requires non-NULL reps argument (and reps_null, if applicable).')
+  if (rescale == "ppmc" && (is.null(reps) || (null_model && is.null(reps_null)))) {
+    stop('blavaan ERROR: rescale="ppmc" requires non-NULL reps argument (and reps_null, if applicable).')
+  }
+  ##FIXME TDJ: postpred(discFUN = ) argument would enable type = "mcmc".
+  ##           Just calculate any fit indices using each posterior sample.
+  ##           Add fit.measures= argument here and above. How to handle CFI...?
   
   ## Compute number of modeled moments
   p <- ((nvar * (nvar + 1)) / 2)
@@ -103,32 +227,64 @@ BayesRelFit <- function(obs, reps = NULL, nvar, pD, N, ms = TRUE, Min1 = FALSE,
   nonc <- obs - reps - dif.ppD # == obs - p when rescale == "devm" because reps = pD
   ## Correct if numerator is smaller than zero
   nonc[nonc < 0] <- 0
+  
+  ## assemble results in a vector
+  result <- list()
+  
   ## Compute BRMSEA
-  BRMSEA <- sqrt(nonc / (dif.ppD * N)) * sqrt(Ngr)
+  if ("brmsea" %in% fit.measures) {
+    result[["BRMSEA"]] <- sqrt(nonc / (dif.ppD * N)) * sqrt(Ngr)
+  }
   
   ## compute GammaHat and adjusted GammaHat
-  gammahat <- nvar / (nvar + 2*nonc/N)
-  adjgammahat <- 1 - (p / dif.ppD) * (1 - gammahat)
-  
+  if ("bgammahat" %in% fit.measures) {
+    result[["BGammaHat"]] <- nvar / (nvar + 2*nonc/N)
+    if ("adjbgammahat" %in% fit.measures) {
+      result[["adjBGammaHat"]] <- 1 - (p / dif.ppD) * (1 - result[["BGammaHat"]])
+    }
+  } else if ("adjbgammahat" %in% fit.measures) {
+    gammahat <- nvar / (nvar + 2*nonc/N)
+    result[["adjBGammaHat"]] <- 1 - (p / dif.ppD) * (1 - gammahat)
+  }
+
   ## compute McDonald's centrality index
-  Mc <- exp(-.5 * nonc/N)
-  
-  out <- cbind(chi_adj = obs - reps, df_adj = dif.ppD, BRMSEA = BRMSEA,
-               BGammaHat = gammahat, adjBGammaHat = adjgammahat, BMc = Mc)
-  
-  ## calculate fit when null model is provided
+  if ("bmc" %in% fit.measures) {
+    result[["BMc"]] <- exp(-.5 * nonc/N)
+  }
+
+  ## calculate incremental fit when null model is provided
   if (null_model) {
     dif.ppD_null <- p - pD_null
     nonc_null <- (obs_null - reps_null) - dif.ppD_null
     
-    cfi <- 1 - (nonc / nonc_null)
-    tli_null_part <- (obs_null - reps_null) / dif.ppD_null
-    tli <- (tli_null_part - (obs - reps) / dif.ppD) / (tli_null_part - 1)
-    nfi <- ((obs_null - reps_null) - (obs - reps)) / (obs_null - reps_null)
-    
-    out <- cbind(out, BCFI = cfi, BTLI = tli, BNFI = nfi)
+    if ("bcfi" %in% fit.measures) {
+      result[["BCFI"]] <- 1 - (nonc / nonc_null)
+    }
+    if ("btli" %in% fit.measures) {
+      tli_null_part <- (obs_null - reps_null) / dif.ppD_null
+      result[["BTLI"]] <- (tli_null_part - (obs - reps) / dif.ppD) / (tli_null_part - 1)
+    }
+    if ("bnfi" %in% fit.measures) {
+      result[["BNFI"]] <- ((obs_null - reps_null) - (obs - reps)) / (obs_null - reps_null)
+    }
   }
   
-  class(out) <- c("lavaan.matrix","matrix")
-  return(out)
+  out <- new("blavFitIndices",
+             details = list(chisq = obs - reps, df = dif.ppD,
+                            pD = pD, rescale = rescale),
+             indices = result)
+  ## for print methods
+  for (i in seq_along(out@details)) {
+    class1 <- class(out@details[[i]])
+    class(out@details[[i]]) <- c("lavaan.vector", class1)
+  }
+  for (i in seq_along(out@indices)) {
+    class(out@indices[[i]]) <- c("lavaan.vector","numeric")
+  }
+  
+  out
 }
+
+
+
+

--- a/R/ctr_bayes_fit.R
+++ b/R/ctr_bayes_fit.R
@@ -276,10 +276,8 @@ BayesChiFit <- function(obs, reps = NULL, nvar, pD, N, Ngr = 1,
                             pD = pD, rescale = rescale),
              indices = result)
   ## for print methods
-  for (i in seq_along(out@details)) {
-    class1 <- class(out@details[[i]])
-    class(out@details[[i]]) <- c("lavaan.vector", class1)
-  }
+  class(out@details$chisq) <- c("lavaan.vector","numeric")
+  class(out@details$df) <- c("lavaan.vector","numeric")
   for (i in seq_along(out@indices)) {
     class(out@indices[[i]]) <- c("lavaan.vector","numeric")
   }

--- a/R/postpred.R
+++ b/R/postpred.R
@@ -21,7 +21,7 @@ postpred <- function(lavpartable, lavmodel, lavoptions,
       if (!(is.function(discFUN) || allFuncs)) stop('The "discFUN" argument must',
                                                     ' be a (list of) function(s).')
     }
-    discFUN <- NULL # Not implemented yet
+    discFUN <- NULL #FIXME: Not implemented yet
   
     ## run through lavjags$mcmc, generate data from various posterior
     ## samples. thin like we do in samp_lls
@@ -99,7 +99,9 @@ postpred <- function(lavpartable, lavmodel, lavoptions,
         chisq.obs <- -2*(samplls[i, j, 1] -
                          samplls[i, j, 2])
         
-        #FIXME TDJ: apply custom "discFUN" here
+        #FIXME TDJ: Apply custom "discFUN" here.
+        #           Need to create a lavaan object using original data,
+        #           like the hack below does for generated data.
   
         ## check for missing, to see if we can easily get baseline ll for chisq
         mis <- FALSE

--- a/man/blavFitIndices.Rd
+++ b/man/blavFitIndices.Rd
@@ -19,8 +19,10 @@ summary(object, central.tendency = c("mean","median","mode"),
 }
 \arguments{
   \item{object}{An object of class \code{\linkS4class{blavaan}}.}
-  \item{pD}{\code{character} indicating from which information criterion to
-    use the estimated number of parameters.}
+  \item{pD}{\code{character} indicating from which information criterion
+    returned by \code{fitMeasures(object)} to use the estimated number of
+    parameters. The default is from the leave-one-out information criterion
+    (LOO-IC), which is most highly recommended by Vehtari et al. (2017).}
   \item{rescale}{\code{character} indicating the method used to calculate
     fit indices. If \code{rescale = "devM"} (default), the Bayesian analog of
     the \eqn{\chi^2} statistic (the deviance evaluated at the posterior mean
@@ -29,7 +31,7 @@ summary(object, central.tendency = c("mean","median","mode"),
     \code{rescale = "PPMC"}, the deviance at each iteration is rescaled by
     subtracting the deviance of data simulated from the posterior predictive
     distribution (as in posterior predictive model checking; see Hoofs et al.,
-    in press). If \code{rescale = "MCMC"} (not implemented yet), the fit
+    2017). If \code{rescale = "MCMC"} (not implemented yet), the fit
     measures are simply calculated at each iteration of the Markov chain(s),
     based on the model-implied moments at that iteration.}
   \item{fit.measures}{If \code{"all"}, all fit measures available will be
@@ -54,7 +56,7 @@ summary(object, central.tendency = c("mean","median","mode"),
   \item{prob}{The "confidence" level of the credible interval(s).}
 }
 \value{
-  An S4 object of class 'blavFitIndices' consisting of 2 slots:
+  An S4 object of class \code{blavFitIndices} consisting of 2 slots:
   \item{\code{@details}}{A \code{list} containing the choices made by the user
     (or defaults; e.g., which values of \code{pD} and \code{rescale} were set),
     as well as the posterior distribution of the \eqn{\chi^2} (deviance)
@@ -68,7 +70,7 @@ summary(object, central.tendency = c("mean","median","mode"),
   and (if requested) the HPD credible-interval limits.
 }
 \author{
-Mauricio Garnier-Villareal (University of Marquette;
+Mauricio Garnier-Villareal (MarquetteUniversity;
 \email{mauricio.garniervillarreal@marquette.edu})
 
 Terrence D. Jorgensen (University of Amsterdam; \email{TJorgensen314@gmail.com})
@@ -76,7 +78,7 @@ Terrence D. Jorgensen (University of Amsterdam; \email{TJorgensen314@gmail.com})
 \references{
   \code{rescale = "PPMC"} based on:
   
-  Hoofs, H., van de Schoot, R., Jansen, N. W., & Kant, I. (in press).
+  Hoofs, H., van de Schoot, R., Jansen, N. W., & Kant, I. (2017).
   Evaluating model fit in Bayesian confirmatory factor analysis with large
   samples: Simulation study introducing the BRMSEA. 
   \emph{Educational and Psychological Measurement}. doi:10.1177/0013164417709314
@@ -86,6 +88,13 @@ Terrence D. Jorgensen (University of Amsterdam; \email{TJorgensen314@gmail.com})
   Garnier-Villarreal, M., & Jorgensen, T. D. (2018).
   \emph{Adapting fit indices for Bayesian SEM: Comparison to maximum likelihood}.
   Unpublished manuscript (see \url{https://osf.io/afkcw/}).
+  
+  Other references:
+  
+  Vehtari, A., Gelman, A., & Gabry, J. (2017). Practical Bayesian model
+  evaluation using leave-one-out cross-validation and WAIC.
+  \emph{Statistics and Computing, 27}(5), 1413--1432.
+  doi:10.1007/s11222-016-9696-4
   
 }
 \examples{ \dontrun{
@@ -110,7 +119,7 @@ summary(ML)
 
 ## other options:
 
-## - use Hoofs et al.'s (in press) PPMC-based method
+## - use Hoofs et al.'s (2017) PPMC-based method
 ## - use the estimated number of parameters from WAIC instead of LOO-IC
 PPMC <- blavFitIndices(fit1, baseline.model = fit0,
                        pD = "waic", rescale = "PPMC")
@@ -119,5 +128,30 @@ PPMC <- blavFitIndices(fit1, baseline.model = fit0,
 ## - specify only the desired measures of central tendency
 ## - specify a different "confidence" level for the credible intervals
 summary(PPMC, central.tendency = c("mean","mode"), prob = .95)
+
+
+
+## Access the posterior distributions for further investigation
+head(distML <- data.frame(ML@indices))
+
+## For example, diagnostic plots using the bayesplot package:
+
+## distinguish chains
+nChains <- blavInspect(fit1, "n.chains")
+distML$Chain <- rep(1:nChains, each = nrow(distML) / nChains)
+
+library(bayesplot)
+mcmc_pairs(distML, pars = c("BRMSEA","BMc","BGammaHat","BCFI","BTLI"),
+           diag_fun = "hist")
+## Indices are highly correlated across iterations in both chains
+
+## Compare to PPMC method
+distPPMC <- data.frame(PPMC@indices)
+distPPMC$Chain <- rep(1:nChains, each = nrow(distPPMC) / nChains)
+mcmc_pairs(distPPMC, pars = c("BRMSEA","BMc","BGammaHat","BCFI","BTLI"),
+           diag_fun = "dens")
+## nonlinear relation between BRMSEA, related to the floor effect of BRMSEA
+## that Hoofs et al. found for larger (12-indicator) models
+
 }}
 

--- a/man/blavFitIndices.Rd
+++ b/man/blavFitIndices.Rd
@@ -70,7 +70,7 @@ summary(object, central.tendency = c("mean","median","mode"),
   and (if requested) the HPD credible-interval limits.
 }
 \author{
-Mauricio Garnier-Villareal (MarquetteUniversity;
+Mauricio Garnier-Villareal (Marquette University;
 \email{mauricio.garniervillarreal@marquette.edu})
 
 Terrence D. Jorgensen (University of Amsterdam; \email{TJorgensen314@gmail.com})

--- a/man/blavFitIndices.Rd
+++ b/man/blavFitIndices.Rd
@@ -1,0 +1,123 @@
+\name{blavFitIndices}
+\alias{blavFitIndices}
+\alias{blavFitIndices-class}
+\alias{show,blavFitIndices-method}
+\alias{summary,blavFitIndices-method}
+\title{SEM Fit Indices for Bayesian SEM}
+\description{
+This function provides a posterior distribution of some \eqn{\chi^2}-based fit
+indices to assess the global fit of a latent variable model.}
+\usage{
+blavFitIndices(object, pD = c("loo","waic","dic"),
+               rescale = c("devM","ppmc","mcmc"),
+               fit.measures = "all", baseline.model = NULL)
+
+## S4 method for signature 'blavFitIndices'
+
+summary(object, central.tendency = c("mean","median","mode"),
+        hpd = TRUE, prob = .90)
+}
+\arguments{
+  \item{object}{An object of class \code{\linkS4class{blavaan}}.}
+  \item{pD}{\code{character} indicating from which information criterion to
+    use the estimated number of parameters.}
+  \item{rescale}{\code{character} indicating the method used to calculate
+    fit indices. If \code{rescale = "devM"} (default), the Bayesian analog of
+    the \eqn{\chi^2} statistic (the deviance evaluated at the posterior mean
+    of the model parameters) is approximated by rescaling the deviance at each
+    iteration by subtracting the estimated number of parameters. If
+    \code{rescale = "PPMC"}, the deviance at each iteration is rescaled by
+    subtracting the deviance of data simulated from the posterior predictive
+    distribution (as in posterior predictive model checking; see Hoofs et al.,
+    in press). If \code{rescale = "MCMC"} (not implemented yet), the fit
+    measures are simply calculated at each iteration of the Markov chain(s),
+    based on the model-implied moments at that iteration.}
+  \item{fit.measures}{If \code{"all"}, all fit measures available will be
+    returned. If only a single or a few fit measures are specified by name,
+    only those are computed and returned. If \code{rescale = "devM"} or
+    \code{"PPMC"}, the currently available indices are \code{"BRMSEA"},
+    \code{"BGammaHat"}, \code{"adjBGammaHat"}, \code{"BMc"}, \code{"BCFI"},
+    \code{"BTLI"}, or \code{"BNFI"}. If \code{rescale = "MCMC"}, the user may
+    request any indices returned by \code{\link[lavaan]{fitMeasures}} for
+    objects of class \code{\linkS4class{lavaan}}.}
+  \item{baseline.model}{If not \code{NULL}, an object of class 
+    \code{\linkS4class{blavaan}}, representing a user-specified baseline model.
+    If a \code{baseline.model} is provided, incremental fit indices (BCFI,
+    BTLI, or BNFI) can be requested in \code{fit.measures}.}
+  \item{central.tendency}{\code{character} indicating which statistics should
+    be used to characterize the location of the posterior distribution. By
+    default, all 3 statistics are returned. The posterior mean is labeled
+    \code{EAP} for \emph{expected a posteriori} estimate, and the mode is
+    labeled \code{MAP} for \emph{modal a posteriori} estimate.}
+  \item{hpd}{\code{logical} indicating whether to calculate the highest
+    posterior density (HPD) credible interval for each fit index.}
+  \item{prob}{The "confidence" level of the credible interval(s).}
+}
+\value{
+  An S4 object of class 'blavFitIndices' consisting of 2 slots:
+  \item{\code{@details}}{A \code{list} containing the choices made by the user
+    (or defaults; e.g., which values of \code{pD} and \code{rescale} were set),
+    as well as the posterior distribution of the \eqn{\chi^2} (deviance)
+    statistic (rescaled, if \code{rescale = "devM"} or \code{"PPMC"}).}
+  \item{\code{@indices}}{A \code{list} containing the posterior distribution
+    of each requested \code{fit.measure}.}
+  
+  The \code{summary()} method returns a \code{data.frame} containing one row
+  for each requested \code{fit.measure}, and columns containing the specified
+  measure(s) of \code{central.tendency}, the posterior \emph{SD},
+  and (if requested) the HPD credible-interval limits.
+}
+\author{
+Mauricio Garnier-Villareal (University of Marquette;
+\email{mauricio.garniervillarreal@marquette.edu})
+
+Terrence D. Jorgensen (University of Amsterdam; \email{TJorgensen314@gmail.com})
+}
+\references{
+  \code{rescale = "PPMC"} based on:
+  
+  Hoofs, H., van de Schoot, R., Jansen, N. W., & Kant, I. (in press).
+  Evaluating model fit in Bayesian confirmatory factor analysis with large
+  samples: Simulation study introducing the BRMSEA. 
+  \emph{Educational and Psychological Measurement}. doi:10.1177/0013164417709314
+  
+  \code{rescale = "devM"} based on:
+  
+  Garnier-Villarreal, M., & Jorgensen, T. D. (2018).
+  \emph{Adapting fit indices for Bayesian SEM: Comparison to maximum likelihood}.
+  Unpublished manuscript (see \url{https://osf.io/afkcw/}).
+  
+}
+\examples{ \dontrun{
+HS.model <- ' visual  =~ x1 + x2 + x3
+              textual =~ x4 + x5 + x6
+              speed   =~ x7 + x8 + x9 '
+## fit target model
+fit1 <- bcfa(HS.model, data = HolzingerSwineford1939, cp = "fa",
+             n.chains = 2, burnin = 1000, sample = 1000)
+
+## fit null model to calculate CFI, TLI, and NFI 
+null.model <- c(paste0("x", 1:9, " ~~ x", 1:9), paste0("x", 1:9, " ~ 1"))
+fit0 <- bcfa(null.model, data = HolzingerSwineford1939, cp = "fa",
+             n.chains = 2, burnin = 1000, sample = 1000)
+
+## calculate posterior distributions of fit indices
+
+## The default method mimics fit indices derived from ML estimation
+ML <- blavFitIndices(fit1, baseline.model = fit0)
+ML
+summary(ML)
+
+## other options:
+
+## - use Hoofs et al.'s (in press) PPMC-based method
+## - use the estimated number of parameters from WAIC instead of LOO-IC
+PPMC <- blavFitIndices(fit1, baseline.model = fit0,
+                       pD = "waic", rescale = "PPMC")
+## issues a warning about using rescale="PPMC" with N < 1000 (see Hoofs et al.)
+
+## - specify only the desired measures of central tendency
+## - specify a different "confidence" level for the credible intervals
+summary(PPMC, central.tendency = c("mean","mode"), prob = .95)
+}}
+


### PR DESCRIPTION
Hi Ed,

I changed the name of `BayesFIT()` to `blavFitIndices()` and added documentation.  It now returns an S4 class object, which has `show()` and `summary()` methods.  If you are comfortable making this public, I added it to the exported functions in `NAMESPACE`.

The little conflict on the last commit was just that I hadn't pulled from your version since your changes yesterday, when I committed my changes that I had in an open R session since the day before.  The conflict is resolved, though (I had only added a couple comments to postpred.R).  I was going to work on the custom discrepancy function in `postpred()`, but I see now that a lavaan object is only created for generated data, not original data (since those log-likelihoods are passed via the argument).  When I have time, I suppose I will copy the hack used for generated data so that the discrepancy function can be applied to original data as well.  Unless you have another idea about how that could go... I haven't even checked to see whether it would be problematic to apply the hack in the case of complete data (since it is only applied now when there are missing data).  Next time.