### PR TITLE
add samplls to the postpred call

### DIFF
--- a/R/ctr_ppmc.R
+++ b/R/ctr_ppmc.R
@@ -508,6 +508,7 @@ ppmc <- function(object, thin = 1, fit.measures = c("srmr","chisq"),
                   lavdata = object@Data,
                   lavcache = object@Cache,
                   lavjags = object@external$mcmcout,
+                  samplls = object@external$samplls,
                   measure = fit.measures, thin = thin, discFUN = discFUN)
 
   ## "out" is a list:


### PR DESCRIPTION
with the latest version, ppmc crashed, because the call of postpred didnt have a samplls with no default