### PR TITLE
add paste0('p_', pD) to basline model fitMeasures

### DIFF
--- a/R/ctr_bayes_fit.R
+++ b/R/ctr_bayes_fit.R
@@ -189,7 +189,7 @@ blavFitIndices <- function(object, thin = 1, pD = c("loo","waic","dic"),
                               lavjags = baseline.model@external$mcmcout,
                               samplls = baseline.model@external$samplls)$ppdist[["reps"]]
       }
-      pD_null <- fitMeasures(baseline.model, 'p_loo')
+      pD_null <- fitMeasures(baseline.model, paste0('p_', pD))
     }
   }
 


### PR DESCRIPTION
add paste0('p_', pD) to basline model fitMeasures. This way the baseline model will use the pD selected by the user. Before it had the LOO pD as fixed, even if the user specified another one