### PR TITLE
Update deprecated syntax for future rstan compatibility

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,8 +35,8 @@ Description: Fit a variety of Bayesian latent variable models, including confirm
 License: GPL (>= 3)
 ByteCompile: true
 Depends: R(>= 3.5.0), methods, Rcpp(>= 0.12.15)
-Imports: stats, utils, graphics, lavaan(>= 0.6-16), coda, mnormt, nonnest2(>= 0.5-5), loo(>= 2.0), rstan(>= 2.21.2), rstantools(>= 1.5.0), RcppParallel (>= 5.0.1), bayesplot, Matrix, future.apply, tmvnsim
-LinkingTo: StanHeaders (>= 2.18.1), rstan (>= 2.21.2), BH (>= 1.69.0), Rcpp (>= 0.12.15), RcppEigen (>= 0.3.3.4.0), RcppParallel (>= 5.0.1)
+Imports: stats, utils, graphics, lavaan(>= 0.6-16), coda, mnormt, nonnest2(>= 0.5-5), loo(>= 2.0), rstan(>= 2.26.0), rstantools(>= 1.5.0), RcppParallel (>= 5.0.1), bayesplot, Matrix, future.apply, tmvnsim
+LinkingTo: StanHeaders (>= 2.26.0), rstan (>= 2.26.0), BH (>= 1.69.0), Rcpp (>= 0.12.15), RcppEigen (>= 0.3.3.4.0), RcppParallel (>= 5.0.1)
 Suggests: runjags(>= 2.0.4-3), modeest(>= 2.3.3), rjags, cmdstanr, semTools, tinytest
 SystemRequirements: GNU make
 NeedsCompilation: yes

--- a/inst/stanfuns/sem_lv.stan
+++ b/inst/stanfuns/sem_lv.stan
@@ -1,14 +1,14 @@
-  real sem_lv_lpdf(matrix x, real[,,] alpha, real[,,] B, real[,,] psi, real[,,] gamma, int gamind, real[,] meanx, int[] g, int k, int N, int Ng, int diagpsi, int fullbeta, int nlv, int[] lvind, int nlvno0){
-    real ldetcomp[Ng];
+  real sem_lv_lpdf(matrix x, array[,,] real alpha, array[,,] real B, array[,,] real psi, array[,,] real gamma, int gamind, array[,] real meanx, array[] int g, int k, int N, int Ng, int diagpsi, int fullbeta, int nlv, array[] int lvind, int nlvno0){
+    array[Ng] real ldetcomp;
     matrix[k,k] iden;
-    vector[k] alpha2[Ng];
-    vector[k] psivecinv[Ng];
-    matrix[k,k] psimatinv[Ng];
-    matrix[k,k] psimat[Ng];
-    matrix[k,k] siginv[Ng];
+    array[Ng] vector[k] alpha2;
+    array[Ng] vector[k] psivecinv;
+    array[Ng] matrix[k,k] psimatinv;
+    array[Ng] matrix[k,k] psimat;
+    array[Ng] matrix[k,k] siginv;
     vector[k] xvec;
-    vector[k] evlv[Ng];
-    int idx[(k-nlv+nlvno0)];
+    array[Ng] vector[k] evlv;
+    array[(k-nlv+nlvno0)] int idx;
     real xvectm;
     real ldetsum;
     int nov;

--- a/inst/stanfuns/sem_lv_missing.stan
+++ b/inst/stanfuns/sem_lv_missing.stan
@@ -1,15 +1,15 @@
-  real sem_lv_missing_lpdf(matrix x, real[,,] alpha, real[,,] B, real[,,] psi, real[,,] gamma, int gamind, real[,] meanx, int[] g, int k, int N, int Ng, int diagpsi, int fullbeta, int nlv, int[] lvind, int nlvno0, int[,] nseen, int[,,] obsvar, int[] obspatt, int[] gpatt){
-    real ldetcomp[Ng,max(gpatt)];
+  real sem_lv_missing_lpdf(matrix x, array[,,] real alpha, array[,,] real B, array[,,] real psi, array[,,] real gamma, int gamind, array[,] real meanx, array[] int g, int k, int N, int Ng, int diagpsi, int fullbeta, int nlv, array[] int lvind, int nlvno0, array[,] int nseen, array[,,] int obsvar, array[] int obspatt, array[] int gpatt){
+    array[Ng,max(gpatt)] real ldetcomp;
     matrix[k,k] iden;
-    vector[k] alpha2[Ng];
-    vector[k] psivecinv[Ng];
-    matrix[k,k] psimatinv[Ng];
-    matrix[k,k] psimat[Ng];
-    matrix[k,k] siginv[Ng,max(gpatt)];
+    array[Ng] vector[k] alpha2;
+    array[Ng] vector[k] psivecinv;
+    array[Ng] matrix[k,k] psimatinv;
+    array[Ng] matrix[k,k] psimat;
+    array[Ng,max(gpatt)] matrix[k,k] siginv;
     vector[k] xvec;
-    vector[k] evlv[Ng];
-    int idx[(k-nlv+nlvno0)];
-    int tmpobs[k];
+    array[Ng] vector[k] evlv;
+    array[(k-nlv+nlvno0)] int idx;
+    array[k] int tmpobs;
     real xvectm;
     real ldetsum;
     int nov;

--- a/inst/stanfuns/sem_mean.stan
+++ b/inst/stanfuns/sem_mean.stan
@@ -1,6 +1,6 @@
-  vector[] sem_mean(vector[] alpha, real[,,] B, real[,,] gamma, int[] g, int k, int Ng, int gamind, real[,] meanx){
+  array[] vector sem_mean(array[] vector alpha, array[,,] real B, array[,,] real gamma, array[] int g, int k, int Ng, int gamind, array[,] real meanx){
     matrix[k,k] iden;
-    vector[k] evlv[Ng];
+    array[Ng] vector[k] evlv;
 
     iden = diag_matrix(rep_vector(1.0, k));
 

--- a/inst/stanfuns/sem_mean_eta.stan
+++ b/inst/stanfuns/sem_mean_eta.stan
@@ -1,9 +1,9 @@
-  vector[] sem_mean_eta(real[,,] alpha, matrix eta, real[,,] B, real[,,] gamma, int[] g, int k, int N, int Ng, int nlv, int[] lvind, int[] lv0ind){
+  array[] vector sem_mean_eta(array[,,] real alpha, matrix eta, array[,,] real B, array[,,] real gamma, array[] int g, int k, int N, int Ng, int nlv, array[] int lvind, array[] int lv0ind){
     matrix[k,k] iden;
-    matrix[k,k] ibinv[Ng];
-    vector[k] evlv[N];
-    real alphvec[k,1,Ng];
-    int idx[(k - nlv + size(lvind))];
+    array[Ng] matrix[k,k] ibinv;
+    array[N] vector[k] evlv;
+    array[k,1,Ng] real alphvec;
+    array[(k - nlv + size(lvind))] int idx;
     int nov;
     int nlvno0;
 


### PR DESCRIPTION
Now that rstan 2.26 is available on CRAN we need to update the deprecated syntax in your package's Stan models, otherwise it will fail to install with an upcoming version of RStan. 

The following updates have been made:

- New array syntax
- `fabs` replaced by `abs`

It also looks the R functions for translating to Stan code will need to be updated as well

More information about the deprecated and removed syntax in Stan can be found here:
- https://mc-stan.org/docs/functions-reference/deprecated-functions.html
- https://mc-stan.org/docs/functions-reference/removed-functions.html

If you could merge and submit to CRAN soon, it would be greatly appreciated.

Feel free to let me know if you have any questions about these changes.

Thanks!
