### PR TITLE
deprecate summary(std.nox=) argument

### DIFF
--- a/R/blav_object_methods.R
+++ b/R/blav_object_methods.R
@@ -70,7 +70,7 @@ function(object, header       = TRUE,
                  ci           = TRUE,
                  standardized = FALSE,
                  rsquare      = FALSE,
-                 std.nox      = FALSE,
+                 std.nox      = FALSE, #TODO: remove deprecated argument in early 2025
                  psrf         = TRUE,
                  neff         = FALSE,
                  postmedian   = FALSE,
@@ -79,7 +79,7 @@ function(object, header       = TRUE,
                  bf           = FALSE,
                  nd = 3L) {
 
-    if(std.nox) standardized <- TRUE
+    #TODO: remove (deprecated):  if(std.nox) standardized <- TRUE
 
     # print the 'short' summary
     if(header) {
@@ -122,9 +122,10 @@ function(object, header       = TRUE,
 
         if(!("group" %in% names(PE))) PE$group <- 1
         if(!("level" %in% names(PE))) PE$level <- "within"
-        if(standardized && std.nox) {
-            PE$std.all <- PE$std.nox
-        }
+        #TODO: remove deprecated argument in early 2025
+        # if(standardized && std.nox) {
+        #     PE$std.all <- PE$std.nox
+        # }
         PE$group[PE$group == 0] <- 1
 
         if("target" %in% names(object@call)){


### PR DESCRIPTION
This is for consistency with deprecating the `std.nox=` argument in lavaan: https://github.com/yrosseel/lavaan/pull/326

This prevents the following error (thanks to Victoria Savalei for the reprex):

```
library(lavaan) #0.6-18.2018
library(blavaan) #blavaan 0.5-3

HS.model <- ' visual  =~ x1 + x2 + x3 
              textual =~ x4 + x5 + x6
              speed   =~ x7 + x8 + x9 '

fit <- cfa(HS.model, data = HolzingerSwineford1939)
summary(fit)

# Error in lav_object_summary(object = object, ...  : 
# unused argument (std.nox = std.nox)
```
