### PR TITLE
Use number of samples available in the posterior for `sampleData`

### DIFF
--- a/R/postpred.R
+++ b/R/postpred.R
@@ -327,8 +327,8 @@ postpred <- function(samplls = NULL, lavobject = NULL, measure = "logl", thin = 
 ## exported function for sampling data from prior or posterior
 sampleData <- sampledata <- function(object, nrep = NULL, conditional = FALSE, type = "response", simplify = FALSE, ...){
   blavoptions <- blavInspect(object, 'options')
-
-  maxreps <- with(blavoptions, n.chains * sample)
+  nsamps <- length(sampnums(object@external$mcmcout, thin = 1))
+  maxreps <- blavoptions$n.chains * nsamps
   if (is.null(nrep)) nrep <- maxreps
   if (nrep > maxreps) stop("blavaan ERROR: nrep must be <= total number of posterior samples")
   if (!blavoptions$do.fit) stop("blavaan ERROR: to sample data, do.fit must be TRUE")


### PR DESCRIPTION
Currently `sampleData` takes the number of posterior samples reported by `blavInspect(_, 'options')` , but the actual number of available samples might be lower if the user also requested thinning via `bcontrol`.

For consistency, I took the approach that [blavPredict](https://github.com/ecmerkle/blavaan/blob/4b03d27b76f461f7dfd75ec1a031a3300aa4793b/R/blav_predict.R#L81-L82) uses to obtain the number of samples.

As an interesting fact, the reason this was not producing any errors is that [this line](https://github.com/ecmerkle/blavaan/blob/4b03d27b76f461f7dfd75ec1a031a3300aa4793b/R/postpred.R#L389), when given `thin` > `nsamps`, produces a vector with non-integer indices, which R just silently rounds down during subsetting.