### PR TITLE
Fix pkgdown navbar search box (#104)

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -15,8 +15,12 @@ news:
 
 navbar:
   title: "blavaan"
-  left:
-    - text: Basics
+  structure:
+    left:  [basics, examples, news, resources, functions]
+    right: [search, github, googlegroups]
+  components:
+    basics:
+      text: Basics
       menu:
       - text: Getting Started
         href: articles/start.html
@@ -25,12 +29,13 @@ navbar:
       - text: Estimation
         href: articles/estimate.html
       - text: Convergence and Efficiency Evaluation
-        href: articles/convergence_efficiency.html        
+        href: articles/convergence_efficiency.html
       - text: Model Summaries
         href: articles/summaries.html
       - text: Plots
         href: articles/plotting.html
-    - text: Examples/Details
+    examples:
+      text: Examples/Details
       menu:
       - text: Estimation with Ordinal Data
         href: articles/ordinal.html
@@ -51,15 +56,21 @@ navbar:
       - text: Convergence Loop
         href: articles/convergence_loop.html
       - text: Probability of Direction
-        href: articles/probability_direction.html          
-    - text: News
+        href: articles/probability_direction.html
+    news:
+      text: News
       href: news/index.html
-    - text: Resources
+    resources:
+      text: Resources
       href: articles/resources.html
-    - text: Functions
+    functions:
+      text: Functions
       href: reference/index.html
-  right:
-   - icon: "fab fa-github fa-lg"
-     href: https://github.com/ecmerkle/blavaan
-   - icon: fa-users
-     href: https://groups.google.com/d/forum/blavaan
+    github:
+      icon: "fab fa-github fa-lg"
+      href: https://github.com/ecmerkle/blavaan
+      aria-label: GitHub
+    googlegroups:
+      icon: fa-users
+      href: https://groups.google.com/d/forum/blavaan
+      aria-label: Google Groups


### PR DESCRIPTION
Fixes #104 --- I think this version seems to be okay

## Problem
The search box never appeared on https://blavaan.org/ even after adding `- search` to the navbar. The root cause is **not** the `params:` vs `bslib:` bootswatch key (that was already corrected); it's the **legacy navbar syntax**. `_pkgdown.yml` defined `navbar.left` / `navbar.right` as inline lists of menu items, which bypasses pkgdown 2.x's navbar `structure`. As a result the built-in `search` component is never inserted, and a bare `- search` list item isn't a valid menu item, so the earlier attempt had no effect.

## Fix
Migrate the navbar to the documented Bootstrap 5 `structure:` + `components:` form, with `search` as a first-class entry in `structure.right`:

```yaml
navbar:
  structure:
    left:  [basics, examples, news, resources, functions]
    right: [search, github, googlegroups]
  components:
    ...
```

Also added `aria-label` to the icon-only GitHub and Google Groups links (required for accessibility under BS5).

## Verification
- `pkgdown:::data_navbar()` now emits `<input id="search-input" ... data-search-index="search.json">` in the right navbar; all five left-side menus still render.
- A targeted local build (`init_site()` + `build_home()` + `build_search()`) produced `search.json` and rendered the search box in `index.html`, confirmed working when served over HTTP.
- `pkgdown_sitrep()` is clean apart from a pre-existing note that `DESCRIPTION` `URL:` lists `ecmerkle.github.io/blavaan` rather than the canonical `blavaan.org` site — left unchanged here since it's CRAN-facing metadata and doesn't affect search.

A full `build_site()` (which recompiles the Stan vignettes) will populate the complete search index across reference and article pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)